### PR TITLE
fix: make resource attribute ordering XSD schema compliant

### DIFF
--- a/sep2_common/Cargo.toml
+++ b/sep2_common/Cargo.toml
@@ -10,9 +10,14 @@ keywords = ["energy","DER","20305","SEP2","IEEE2030"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lints.rust]
+# TODO: remove once sepserde_derive stops emitting impls inside `const _ = {…}`
+# blocks (Rust 1.80+ flags those as non-local).
+non_local_definitions = "allow"
+
 [dependencies]
 sep2_common_derive = { version = "0.1.0" }
-sepserde = { version = "0.8.2" }
+sepserde = { version = "0.8.3" }
 xml-rs = "0.8.4"
 log = "0.4.19"
 anyhow = "1.0.72"

--- a/sep2_common/src/lib.rs
+++ b/sep2_common/src/lib.rs
@@ -1,4 +1,4 @@
-use crate::packages::{primitives::HexBinary128, types::MRIDType};
+use crate::packages::types::MRIDType;
 use anyhow::{anyhow, Result};
 use rand::Rng;
 use std::{
@@ -47,7 +47,7 @@ pub fn mrid_gen(pen_id: u32) -> MRIDType {
         .expect("Time went backwards.")
         .as_secs() as u128;
     let count = MRID_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed) as u128;
-    HexBinary128((time << 32) | (id << 32) | (count << 32) | pen_id as u128)
+    MRIDType((time << 32) | (id << 32) | (count << 32) | pen_id as u128)
 }
 
 #[test]

--- a/sep2_common/src/packages/billing.rs
+++ b/sep2_common/src/packages/billing.rs
@@ -127,12 +127,6 @@ impl Validate for BillingPeriodList {}
 #[yaserde(rename = "BillingMeterReadingBase")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct BillingMeterReadingBase {
-    #[yaserde(rename = "BillingReadingSetListLink")]
-    pub billing_reading_set_list_link: Option<BillingReadingSetListLink>,
-
-    #[yaserde(rename = "ReadingTypeLink")]
-    pub reading_type_link: Option<ReadingTypeLink>,
-
     /// The global identifier of the object.
     #[yaserde(rename = "mRID")]
     pub mrid: MRIDType,
@@ -145,6 +139,12 @@ pub struct BillingMeterReadingBase {
     /// details.
     #[yaserde(rename = "version")]
     pub version: Option<VersionType>,
+
+    #[yaserde(rename = "BillingReadingSetListLink")]
+    pub billing_reading_set_list_link: Option<BillingReadingSetListLink>,
+
+    #[yaserde(rename = "ReadingTypeLink")]
+    pub reading_type_link: Option<ReadingTypeLink>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -160,9 +160,6 @@ impl Validate for BillingMeterReadingBase {}
 #[yaserde(rename = "BillingReading")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct BillingReading {
-    #[yaserde(rename = "Charge")]
-    pub charge: Vec<Charge>,
-
     /// Indicates the consumption block related to the reading. REQUIRED if
     /// ReadingType numberOfConsumptionBlocks is non-zero. If not specified, is
     /// assumed to be "0 - N/A".
@@ -200,6 +197,9 @@ pub struct BillingReading {
     /// Value in units specified by ReadingType
     #[yaserde(rename = "value")]
     pub value: Option<Int48>,
+
+    #[yaserde(rename = "Charge")]
+    pub charge: Vec<Charge>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -275,13 +275,6 @@ impl Validate for BillingReadingList {}
 #[yaserde(rename = "BillingReadingSet")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct BillingReadingSet {
-    #[yaserde(rename = "BillingReadingListLink")]
-    pub billing_reading_list_link: Option<BillingReadingListLink>,
-
-    /// Specifies the time range during which the contained readings were taken.
-    #[yaserde(rename = "timePeriod")]
-    pub time_period: DateTimeInterval,
-
     /// The global identifier of the object.
     #[yaserde(rename = "mRID")]
     pub mrid: MRIDType,
@@ -294,6 +287,13 @@ pub struct BillingReadingSet {
     /// details.
     #[yaserde(rename = "version")]
     pub version: Option<VersionType>,
+
+    /// Specifies the time range during which the contained readings were taken.
+    #[yaserde(rename = "timePeriod")]
+    pub time_period: DateTimeInterval,
+
+    #[yaserde(rename = "BillingReadingListLink")]
+    pub billing_reading_list_link: Option<BillingReadingListLink>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -418,6 +418,19 @@ impl Validate for ChargeKind {}
 #[yaserde(rename = "CustomerAccount")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct CustomerAccount {
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
+
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
     /// The ISO 4217 code indicating the currency applicable to the bill amounts
     /// in the summary. See list at
     /// <http://www.unece.org/cefact/recommendations/rec09/rec09_ecetrd203.pdf>
@@ -442,19 +455,6 @@ pub struct CustomerAccount {
 
     #[yaserde(rename = "ServiceSupplierLink")]
     pub service_supplier_link: Option<ServiceSupplierLink>,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -537,6 +537,19 @@ impl Validate for CustomerAccountList {}
 #[yaserde(rename = "CustomerAgreement")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct CustomerAgreement {
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
+
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
     #[yaserde(rename = "ActiveBillingPeriodListLink")]
     pub active_billing_period_list_link: Option<ActiveBillingPeriodListLink>,
 
@@ -574,19 +587,6 @@ pub struct CustomerAgreement {
 
     #[yaserde(rename = "UsagePointLink")]
     pub usage_point_link: Option<UsagePointLink>,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -672,12 +672,6 @@ impl Validate for CustomerAgreementList {}
 #[yaserde(rename = "HistoricalReading")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct HistoricalReading {
-    #[yaserde(rename = "BillingReadingSetListLink")]
-    pub billing_reading_set_list_link: Option<BillingReadingSetListLink>,
-
-    #[yaserde(rename = "ReadingTypeLink")]
-    pub reading_type_link: Option<ReadingTypeLink>,
-
     /// The global identifier of the object.
     #[yaserde(rename = "mRID")]
     pub mrid: MRIDType,
@@ -690,6 +684,12 @@ pub struct HistoricalReading {
     /// details.
     #[yaserde(rename = "version")]
     pub version: Option<VersionType>,
+
+    #[yaserde(rename = "BillingReadingSetListLink")]
+    pub billing_reading_set_list_link: Option<BillingReadingSetListLink>,
+
+    #[yaserde(rename = "ReadingTypeLink")]
+    pub reading_type_link: Option<ReadingTypeLink>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -757,12 +757,6 @@ impl Validate for HistoricalReadingList {}
 #[yaserde(rename = "ProjectionReading")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct ProjectionReading {
-    #[yaserde(rename = "BillingReadingSetListLink")]
-    pub billing_reading_set_list_link: Option<BillingReadingSetListLink>,
-
-    #[yaserde(rename = "ReadingTypeLink")]
-    pub reading_type_link: Option<ReadingTypeLink>,
-
     /// The global identifier of the object.
     #[yaserde(rename = "mRID")]
     pub mrid: MRIDType,
@@ -775,6 +769,12 @@ pub struct ProjectionReading {
     /// details.
     #[yaserde(rename = "version")]
     pub version: Option<VersionType>,
+
+    #[yaserde(rename = "BillingReadingSetListLink")]
+    pub billing_reading_set_list_link: Option<BillingReadingSetListLink>,
+
+    #[yaserde(rename = "ReadingTypeLink")]
+    pub reading_type_link: Option<ReadingTypeLink>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -842,12 +842,6 @@ impl Validate for ProjectionReadingList {}
 #[yaserde(rename = "TargetReading")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct TargetReading {
-    #[yaserde(rename = "BillingReadingSetListLink")]
-    pub billing_reading_set_list_link: Option<BillingReadingSetListLink>,
-
-    #[yaserde(rename = "ReadingTypeLink")]
-    pub reading_type_link: Option<ReadingTypeLink>,
-
     /// The global identifier of the object.
     #[yaserde(rename = "mRID")]
     pub mrid: MRIDType,
@@ -860,6 +854,12 @@ pub struct TargetReading {
     /// details.
     #[yaserde(rename = "version")]
     pub version: Option<VersionType>,
+
+    #[yaserde(rename = "BillingReadingSetListLink")]
+    pub billing_reading_set_list_link: Option<BillingReadingSetListLink>,
+
+    #[yaserde(rename = "ReadingTypeLink")]
+    pub reading_type_link: Option<ReadingTypeLink>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -927,6 +927,19 @@ impl Validate for TargetReadingList {}
 #[yaserde(rename = "ServiceSupplier")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct ServiceSupplier {
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
+
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
     /// E-mail address for this service supplier.
     #[yaserde(rename = "email")]
     pub email: Option<String32>,
@@ -942,19 +955,6 @@ pub struct ServiceSupplier {
     /// Website URI address for this service supplier.
     #[yaserde(rename = "web")]
     pub web: Option<String42>,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.

--- a/sep2_common/src/packages/conn_point.rs
+++ b/sep2_common/src/packages/conn_point.rs
@@ -62,13 +62,15 @@ fn example_connectionpoint() {
 #[test]
 fn connectionpoint_edev() {
     let expected = r#"<EndDevice xmlns="urn:ieee:std:2030.5:ns" xmlns:csipaus="https://csipaus.org/ns">
-  <changedTime>0</changedTime>
-  <csipaus:ConnectionPointLink  href="/edev/1/cp" />
   <sFDI>0</sFDI>
+  <changedTime>0</changedTime>
+  <csipaus:ConnectionPointLink href="/edev/1/cp" />
 </EndDevice>"#;
-    let mut edev = EndDevice::default();
-    edev.connection_point_link = Some(ConnectionPointLink {
-        href: "/edev/1/cp".to_owned(),
-    });
+    let edev = EndDevice {
+        connection_point_link: Some(ConnectionPointLink {
+            href: "/edev/1/cp".to_owned(),
+        }),
+        ..Default::default()
+    };
     assert_eq!(expected, serialize(&edev).unwrap())
 }

--- a/sep2_common/src/packages/dcap.rs
+++ b/sep2_common/src/packages/dcap.rs
@@ -27,22 +27,6 @@ use super::{
 #[yaserde(rename = "DeviceCapability")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct DeviceCapability {
-    #[yaserde(rename = "EndDeviceListLink")]
-    pub end_device_list_link: Option<EndDeviceListLink>,
-
-    #[yaserde(rename = "MirrorUsagePointListLink")]
-    pub mirror_usage_point_list_link: Option<MirrorUsagePointListLink>,
-
-    #[yaserde(rename = "SelfDeviceLink")]
-    pub self_device_link: Option<SelfDeviceLink>,
-
-    /// The default polling rate for this function set (this resource and all
-    /// resources below), in seconds. If not specified, a default of 900 seconds
-    /// (15 minutes) is used. It is RECOMMENDED a client poll the resources of
-    /// this function set every pollRate seconds.
-    #[yaserde(attribute, rename = "pollRate")]
-    pub poll_rate: Option<Uint32>,
-
     #[yaserde(rename = "CustomerAccountListLink")]
     pub customer_account_list_link: Option<CustomerAccountListLink>,
 
@@ -51,6 +35,13 @@ pub struct DeviceCapability {
 
     #[yaserde(rename = "DERProgramListLink")]
     pub der_program_list_link: Option<DERProgramListLink>,
+
+    /// The default polling rate for this function set (this resource and all
+    /// resources below), in seconds. If not specified, a default of 900 seconds
+    /// (15 minutes) is used. It is RECOMMENDED a client poll the resources of
+    /// this function set every pollRate seconds.
+    #[yaserde(attribute, rename = "pollRate")]
+    pub poll_rate: Option<Uint32>,
 
     #[yaserde(rename = "FileListLink")]
     pub file_list_link: Option<FileListLink>,
@@ -72,6 +63,15 @@ pub struct DeviceCapability {
 
     #[yaserde(rename = "UsagePointListLink")]
     pub usage_point_list_link: Option<UsagePointListLink>,
+
+    #[yaserde(rename = "EndDeviceListLink")]
+    pub end_device_list_link: Option<EndDeviceListLink>,
+
+    #[yaserde(rename = "MirrorUsagePointListLink")]
+    pub mirror_usage_point_list_link: Option<MirrorUsagePointListLink>,
+
+    #[yaserde(rename = "SelfDeviceLink")]
+    pub self_device_link: Option<SelfDeviceLink>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.

--- a/sep2_common/src/packages/der.rs
+++ b/sep2_common/src/packages/der.rs
@@ -46,6 +46,19 @@ use crate::serialize;
 #[yaserde(rename = "DefaultDERControl")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct DefaultDERControl {
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
+
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
     #[yaserde(rename = "DERControlBase")]
     pub der_control_base: DERControlBase,
 
@@ -111,19 +124,6 @@ pub struct DefaultDERControl {
     /// (DERSettings::setSoftGradW).
     #[yaserde(rename = "setSoftGradW")]
     pub set_soft_grad_w: Option<Uint16>,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
 
     /// Indicates whether or not subscriptions are supported for this resource,
     /// and whether or not conditional (thresholds) are supported. If not
@@ -282,6 +282,10 @@ impl Validate for DERList {}
 )]
 #[yaserde(rename = "DERSettings")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
+#[cfg_attr(
+    feature = "csip_aus",
+    yaserde(namespace = "csipaus: https://csipaus.org/ns")
+)]
 pub struct DERSettings {
     /// Bitmap indicating the DER Controls enabled on the device. See
     /// DERControlType for values. If a control is supported (see
@@ -435,6 +439,13 @@ pub struct DERSettings {
     #[yaserde(rename = "updatedTime")]
     pub updated_time: TimeType,
 
+    /// Bitmap indicating the DOE controls enabled on the device. See
+    /// DOEControlType for values.
+    #[cfg(feature = "csip_aus")]
+    #[yaserde(rename = "doeModesEnabled")]
+    #[yaserde(prefix = "csipaus", namespace = "csipaus: https://csipaus.org/ns")]
+    pub doe_modes_enabled: Option<DOEControlType>,
+
     /// Indicates whether or not subscriptions are supported for this resource,
     /// and whether or not conditional (thresholds) are supported. If not
     /// specified, is "not subscribable" (0).
@@ -547,12 +558,6 @@ pub struct DERCapability {
     /// DERControlType for values.
     #[yaserde(rename = "modesSupported")]
     pub modes_supported: DERControlType,
-
-    /// Bitmap indicating the CSIP-AUS controls implemented
-    #[cfg(feature = "csip_aus")]
-    #[yaserde(rename = "doeModesSupported")]
-    #[yaserde(prefix = "csipaus", namespace = "csipaus: https://csipaus.org/ns")]
-    pub doe_modes_supported: DOEControlType,
 
     /// Abnormal operating performance category as defined by IEEE 1547-2018. One
     /// of:
@@ -673,6 +678,12 @@ pub struct DERCapability {
     /// Type of DER; see DERType object
     #[yaserde(rename = "type")]
     pub _type: DERType,
+
+    /// Bitmap indicating the CSIP-AUS controls implemented
+    #[cfg(feature = "csip_aus")]
+    #[yaserde(rename = "doeModesSupported")]
+    #[yaserde(prefix = "csipaus", namespace = "csipaus: https://csipaus.org/ns")]
+    pub doe_modes_supported: DOEControlType,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -959,6 +970,13 @@ pub struct DERControlBase {
     #[yaserde(rename = "opModWattVar")]
     pub op_mod_watt_var: Option<DERCurveLink>,
 
+    /// Requested ramp time, in hundredths of a second, for the device to
+    /// transition from the current DERControl mode setting(s) to the new mode
+    /// setting(s). If absent, use default ramp rate (setGradW). Resolution is
+    /// 1/100 sec.
+    #[yaserde(rename = "rampTms")]
+    pub ramp_tms: Option<Uint16>,
+
     /// This is the constraint on the imported active power at the connection point.
     #[cfg(feature = "csip_aus")]
     #[yaserde(rename = "opModImpLimW")]
@@ -986,13 +1004,6 @@ pub struct DERControlBase {
     #[yaserde(rename = "opModLoadLimW")]
     #[yaserde(prefix = "csipaus", namespace = "csipaus: https://csipaus.org/ns")]
     pub op_mod_load_lim_w: Option<ActivePower>,
-
-    /// Requested ramp time, in hundredths of a second, for the device to
-    /// transition from the current DERControl mode setting(s) to the new mode
-    /// setting(s). If absent, use default ramp rate (setGradW). Resolution is
-    /// 1/100 sec.
-    #[yaserde(rename = "rampTms")]
-    pub ramp_tms: Option<Uint16>,
 }
 
 impl DERControlBase {
@@ -1064,14 +1075,29 @@ impl Validate for DERControlBase {}
 #[yaserde(rename = "DERControl")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct DERControl {
-    #[yaserde(rename = "DERControlBase")]
-    pub der_control_base: DERControlBase,
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
 
-    /// Specifies the bitmap indicating the categories of devices that SHOULD
-    /// respond. Devices SHOULD ignore events that do not indicate their device
-    /// category. If not present, all devices SHOULD respond.
-    #[yaserde(rename = "deviceCategory")]
-    pub device_category: Option<DeviceCategoryType>,
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
+    /// The time at which the Event was created.
+    #[yaserde(rename = "creationTime")]
+    pub creation_time: TimeType,
+
+    #[yaserde(rename = "EventStatus")]
+    pub event_status: EventStatus,
+
+    /// The period during which the Event applies.
+    #[yaserde(rename = "interval")]
+    pub interval: DateTimeInterval,
 
     /// Number of seconds boundary inside which a random value must be selected
     /// to be applied to the associated interval duration, to avoid sudden
@@ -1089,29 +1115,14 @@ pub struct DERControl {
     #[yaserde(rename = "randomizeStart")]
     pub randomize_start: Option<OneHourRangeType>,
 
-    /// The time at which the Event was created.
-    #[yaserde(rename = "creationTime")]
-    pub creation_time: TimeType,
+    #[yaserde(rename = "DERControlBase")]
+    pub der_control_base: DERControlBase,
 
-    #[yaserde(rename = "EventStatus")]
-    pub event_status: EventStatus,
-
-    /// The period during which the Event applies.
-    #[yaserde(rename = "interval")]
-    pub interval: DateTimeInterval,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
+    /// Specifies the bitmap indicating the categories of devices that SHOULD
+    /// respond. Devices SHOULD ignore events that do not indicate their device
+    /// category. If not present, all devices SHOULD respond.
+    #[yaserde(rename = "deviceCategory")]
+    pub device_category: Option<DeviceCategoryType>,
 
     /// Indicates whether or not subscriptions are supported for this resource,
     /// and whether or not conditional (thresholds) are supported. If not
@@ -1313,7 +1324,7 @@ impl Validate for DERControlType {}
 #[cfg(feature = "csip_aus")]
 bitflags! {
     #[derive(Default, PartialEq, PartialOrd, Eq, Ord, Clone, Copy, Debug, HexBinaryYaSerde)]
-    pub struct DOEControlType: u16 { // HexBinary 16
+    pub struct DOEControlType: u8 { // HexBinary 8
         const OpModExpLimW = 1;
         const OpModImpLimW = 2;
         const OpModGenLimW = 4;
@@ -1327,6 +1338,19 @@ bitflags! {
 #[yaserde(rename = "DERCurve")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct DERCurve {
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
+
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
     /// If the curveType is opModVoltVar, then this field MAY be present. If the
     /// curveType is not opModVoltVar, then this field SHALL NOT be present.
     /// Enable/disable autonomous vRef adjustment. When enabled, the Volt-Var
@@ -1403,19 +1427,6 @@ pub struct DERCurve {
     /// The Y-axis units context.
     #[yaserde(rename = "yRefType")]
     pub y_ref_type: DERUnitRefType,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -1536,6 +1547,19 @@ impl Validate for DERCurveType {}
 #[yaserde(rename = "DERProgram")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct DERProgram {
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
+
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
     #[yaserde(rename = "ActiveDERControlListLink")]
     pub active_der_control_list_link: Option<ActiveDERControlListLink>,
 
@@ -1551,19 +1575,6 @@ pub struct DERProgram {
     /// Indicates the relative primacy of the provider of this Program.
     #[yaserde(rename = "primacy")]
     pub primacy: PrimacyType,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
 
     /// Indicates whether or not subscriptions are supported for this resource,
     /// and whether or not conditional (thresholds) are supported. If not
@@ -2202,7 +2213,7 @@ impl Validate for StorageModeStatusType {}
 #[test]
 fn dercap_no_csip_aus() {
     let expected = r#"<DERCapability xmlns="urn:ieee:std:2030.5:ns">
-  <modesSupported>0</modesSupported>
+  <modesSupported>00000000</modesSupported>
   <rtgMaxW>
     <multiplier>0</multiplier>
     <value>0</value>
@@ -2218,13 +2229,13 @@ fn dercap_no_csip_aus() {
 #[test]
 fn csip_aus_dercap() {
     let expected = r#"<DERCapability xmlns="urn:ieee:std:2030.5:ns" xmlns:csipaus="https://csipaus.org/ns">
-  <modesSupported>0</modesSupported>
-  <csipaus:doeModesSupported>0</csipaus:doeModesSupported>
+  <modesSupported>00000000</modesSupported>
   <rtgMaxW>
     <multiplier>0</multiplier>
     <value>0</value>
   </rtgMaxW>
   <type>0</type>
+  <csipaus:doeModesSupported>00</csipaus:doeModesSupported>
 </DERCapability>"#;
     let dcap = DERCapability::default();
     let out = serialize(&dcap).unwrap();
@@ -2261,11 +2272,65 @@ fn csip_aus_dercontrolbase() {
     <value>0</value>
   </csipaus:opModLoadLimW>
 </DERControlBase>"#;
-    let mut dercb = DERControlBase::default();
-    dercb.op_mod_imp_lim_w = Some(Default::default());
-    dercb.op_mod_exp_lim_w = Some(Default::default());
-    dercb.op_mod_gen_lim_w = Some(Default::default());
-    dercb.op_mod_load_lim_w = Some(Default::default());
+    let dercb = DERControlBase {
+        op_mod_imp_lim_w: Some(Default::default()),
+        op_mod_exp_lim_w: Some(Default::default()),
+        op_mod_gen_lim_w: Some(Default::default()),
+        op_mod_load_lim_w: Some(Default::default()),
+        ..Default::default()
+    };
     let out = serialize(&dercb).unwrap();
+    assert_eq!(expected, out);
+}
+
+#[test]
+fn derstatus() {
+    let expected = r#"<DERStatus xmlns="urn:ieee:std:2030.5:ns">
+  <alarmStatus>00000001</alarmStatus>
+  <readingTime>0</readingTime>
+</DERStatus>"#;
+    let status = DERStatus {
+        alarm_status: Some(DERAlarmStatus::DER_FAULT_OVER_CURRENT),
+        ..Default::default()
+    };
+    let out = serialize(&status).unwrap();
+    assert_eq!(expected, out);
+    let round_trip: DERStatus = crate::deserialize(&out).unwrap();
+    assert_eq!(round_trip, status);
+}
+
+#[cfg(not(feature = "csip_aus"))]
+#[test]
+fn dersettings_no_csip_aus() {
+    let expected = r#"<DERSettings xmlns="urn:ieee:std:2030.5:ns">
+  <setGradW>0</setGradW>
+  <setMaxW>
+    <multiplier>0</multiplier>
+    <value>0</value>
+  </setMaxW>
+  <updatedTime>0</updatedTime>
+</DERSettings>"#;
+    let dset = DERSettings::default();
+    let out = serialize(&dset).unwrap();
+    assert_eq!(expected, out);
+}
+
+#[cfg(feature = "csip_aus")]
+#[test]
+fn csip_aus_dersettings() {
+    let expected = r#"<DERSettings xmlns="urn:ieee:std:2030.5:ns" xmlns:csipaus="https://csipaus.org/ns">
+  <setGradW>0</setGradW>
+  <setMaxW>
+    <multiplier>0</multiplier>
+    <value>0</value>
+  </setMaxW>
+  <updatedTime>0</updatedTime>
+  <csipaus:doeModesEnabled>00</csipaus:doeModesEnabled>
+</DERSettings>"#;
+    let dset = DERSettings {
+        doe_modes_enabled: Some(Default::default()),
+        ..Default::default()
+    };
+    let out = serialize(&dset).unwrap();
     assert_eq!(expected, out);
 }

--- a/sep2_common/src/packages/drlc.rs
+++ b/sep2_common/src/packages/drlc.rs
@@ -72,6 +72,19 @@ impl Validate for ApplianceLoadReduction {}
 #[yaserde(rename = "DemandResponseProgram")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct DemandResponseProgram {
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
+
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
     #[yaserde(rename = "ActiveEndDeviceControlListLink")]
     pub active_end_device_control_list_link: Option<ActiveEndDeviceControlListLink>,
 
@@ -103,19 +116,6 @@ pub struct DemandResponseProgram {
     /// Indicates the relative primacy of the provider of this program.
     #[yaserde(rename = "primacy")]
     pub primacy: PrimacyType,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -233,6 +233,46 @@ impl Validate for DutyCycle {}
 #[yaserde(rename = "EndDeviceControl")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct EndDeviceControl {
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
+
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
+    /// The time at which the Event was created.
+    #[yaserde(rename = "creationTime")]
+    pub creation_time: TimeType,
+
+    #[yaserde(rename = "EventStatus")]
+    pub event_status: EventStatus,
+
+    /// The period during which the Event applies.
+    #[yaserde(rename = "interval")]
+    pub interval: DateTimeInterval,
+
+    /// Number of seconds boundary inside which a random value must be selected
+    /// to be applied to the associated interval duration, to avoid sudden
+    /// synchronized demand changes. If related to price level changes, sign may
+    /// be ignored. Valid range is -3600 to 3600. If not specified, 0 is the
+    /// default.
+    #[yaserde(rename = "randomizeDuration")]
+    pub randomize_duration: Option<OneHourRangeType>,
+
+    /// Number of seconds boundary inside which a random value must be selected
+    /// to be applied to the associated interval start time, to avoid sudden
+    /// synchronized demand changes. If related to price level changes, sign may
+    /// be ignored. Valid range is -3600 to 3600. If not specified, 0 is the
+    /// default.
+    #[yaserde(rename = "randomizeStart")]
+    pub randomize_start: Option<OneHourRangeType>,
+
     #[yaserde(rename = "ApplianceLoadReduction")]
     pub appliance_load_reduction: Option<ApplianceLoadReduction>,
 
@@ -274,46 +314,6 @@ pub struct EndDeviceControl {
 
     #[yaserde(rename = "TargetReduction")]
     pub target_reduction: Option<TargetReduction>,
-
-    /// Number of seconds boundary inside which a random value must be selected
-    /// to be applied to the associated interval duration, to avoid sudden
-    /// synchronized demand changes. If related to price level changes, sign may
-    /// be ignored. Valid range is -3600 to 3600. If not specified, 0 is the
-    /// default.
-    #[yaserde(rename = "randomizeDuration")]
-    pub randomize_duration: Option<OneHourRangeType>,
-
-    /// Number of seconds boundary inside which a random value must be selected
-    /// to be applied to the associated interval start time, to avoid sudden
-    /// synchronized demand changes. If related to price level changes, sign may
-    /// be ignored. Valid range is -3600 to 3600. If not specified, 0 is the
-    /// default.
-    #[yaserde(rename = "randomizeStart")]
-    pub randomize_start: Option<OneHourRangeType>,
-
-    /// The time at which the Event was created.
-    #[yaserde(rename = "creationTime")]
-    pub creation_time: TimeType,
-
-    #[yaserde(rename = "EventStatus")]
-    pub event_status: EventStatus,
-
-    /// The period during which the Event applies.
-    #[yaserde(rename = "interval")]
-    pub interval: DateTimeInterval,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
 
     /// Indicates whether or not subscriptions are supported for this resource,
     /// and whether or not conditional (thresholds) are supported. If not

--- a/sep2_common/src/packages/edev.rs
+++ b/sep2_common/src/packages/edev.rs
@@ -188,40 +188,6 @@ pub enum OpState {
     yaserde(namespace = "csipaus: https://csipaus.org/ns")
 )]
 pub struct EndDevice {
-    /// The time at which this resource was last modified or created.
-    #[yaserde(rename = "changedTime")]
-    pub changed_time: TimeType,
-
-    /// This attribute indicates whether or not an EndDevice is enabled, or
-    /// registered, on the server. If a server sets this attribute to false, the
-    /// device is no longer registered. It should be noted that servers can
-    /// delete EndDevice instances, but using this attribute for some time is
-    /// more convenient for clients.
-    #[yaserde(rename = "enabled")]
-    pub enabled: Option<bool>,
-
-    #[yaserde(rename = "FlowReservationRequestListLink")]
-    pub flow_reservation_request_list_link: Option<FlowReservationRequestListLink>,
-
-    #[yaserde(rename = "FlowReservationResponseListLink")]
-    pub flow_reservation_response_list_link: Option<FlowReservationResponseListLink>,
-
-    #[yaserde(rename = "FunctionSetAssignmentsListLink")]
-    pub function_set_assignments_list_link: Option<FunctionSetAssignmentsListLink>,
-
-    /// POST rate, or how often EndDevice and subordinate resources should be
-    /// POSTed, in seconds. A client MAY indicate a preferred postRate when
-    /// POSTing EndDevice. A server MAY add or modify postRate to indicate its
-    /// preferred posting rate.
-    #[yaserde(rename = "postRate")]
-    pub post_rate: Option<Uint32>,
-
-    #[yaserde(rename = "RegistrationLink")]
-    pub registration_link: Option<RegistrationLink>,
-
-    #[yaserde(rename = "SubscriptionListLink")]
-    pub subscription_list_link: Option<SubscriptionListLink>,
-
     #[yaserde(rename = "ConfigurationLink")]
     pub configuration_link: Option<ConfigurationLink>,
 
@@ -261,15 +227,49 @@ pub struct EndDevice {
     #[yaserde(rename = "PowerStatusLink")]
     pub power_status_link: Option<PowerStatusLink>,
 
-    #[cfg(feature = "csip_aus")]
-    #[yaserde(prefix = "csipaus", namespace = "csipaus: https://csipaus.org/ns")]
-    #[yaserde(rename = "ConnectionPointLink ")]
-    pub connection_point_link: Option<ConnectionPointLink>,
-
     /// Short form of device identifier, WITH the checksum digit. See the
     /// Security section for additional details.
     #[yaserde(rename = "sFDI")]
     pub sfdi: SFDIType,
+
+    /// The time at which this resource was last modified or created.
+    #[yaserde(rename = "changedTime")]
+    pub changed_time: TimeType,
+
+    /// This attribute indicates whether or not an EndDevice is enabled, or
+    /// registered, on the server. If a server sets this attribute to false, the
+    /// device is no longer registered. It should be noted that servers can
+    /// delete EndDevice instances, but using this attribute for some time is
+    /// more convenient for clients.
+    #[yaserde(rename = "enabled")]
+    pub enabled: Option<bool>,
+
+    #[yaserde(rename = "FlowReservationRequestListLink")]
+    pub flow_reservation_request_list_link: Option<FlowReservationRequestListLink>,
+
+    #[yaserde(rename = "FlowReservationResponseListLink")]
+    pub flow_reservation_response_list_link: Option<FlowReservationResponseListLink>,
+
+    #[yaserde(rename = "FunctionSetAssignmentsListLink")]
+    pub function_set_assignments_list_link: Option<FunctionSetAssignmentsListLink>,
+
+    /// POST rate, or how often EndDevice and subordinate resources should be
+    /// POSTed, in seconds. A client MAY indicate a preferred postRate when
+    /// POSTing EndDevice. A server MAY add or modify postRate to indicate its
+    /// preferred posting rate.
+    #[yaserde(rename = "postRate")]
+    pub post_rate: Option<Uint32>,
+
+    #[yaserde(rename = "RegistrationLink")]
+    pub registration_link: Option<RegistrationLink>,
+
+    #[yaserde(rename = "SubscriptionListLink")]
+    pub subscription_list_link: Option<SubscriptionListLink>,
+
+    #[cfg(feature = "csip_aus")]
+    #[yaserde(prefix = "csipaus", namespace = "csipaus: https://csipaus.org/ns")]
+    #[yaserde(rename = "ConnectionPointLink")]
+    pub connection_point_link: Option<ConnectionPointLink>,
 
     /// Indicates whether or not subscriptions are supported for this resource,
     /// and whether or not conditional (thresholds) are supported. If not
@@ -499,8 +499,8 @@ impl Validate for Temperature {}
 #[test]
 fn csip_aus_edev_no_namespace() {
     let expected = r#"<EndDevice xmlns="urn:ieee:std:2030.5:ns">
-  <changedTime>0</changedTime>
   <sFDI>0</sFDI>
+  <changedTime>0</changedTime>
 </EndDevice>"#;
     let edev = EndDevice::default();
     let out = serialize(&edev).unwrap();
@@ -511,8 +511,8 @@ fn csip_aus_edev_no_namespace() {
 #[test]
 fn csip_aus_edev_namespace() {
     let expected = r#"<EndDevice xmlns="urn:ieee:std:2030.5:ns" xmlns:csipaus="https://csipaus.org/ns">
-  <changedTime>0</changedTime>
   <sFDI>0</sFDI>
+  <changedTime>0</changedTime>
 </EndDevice>"#;
     let edev = EndDevice::default();
     let out = serialize(&edev).unwrap();

--- a/sep2_common/src/packages/flow_reservation.rs
+++ b/sep2_common/src/packages/flow_reservation.rs
@@ -56,6 +56,19 @@ impl Validate for RequestStatus {}
 #[yaserde(rename = "FlowReservationRequest")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct FlowReservationRequest {
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
+
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
     /// The time at which the request was created.
     #[yaserde(rename = "creationTime")]
     pub creation_time: TimeType,
@@ -95,19 +108,6 @@ pub struct FlowReservationRequest {
 
     #[yaserde(rename = "RequestStatus")]
     pub request_status: RequestStatus,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -193,6 +193,30 @@ impl Validate for FlowReservationRequestList {}
 #[yaserde(rename = "FlowReservationResponse")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct FlowReservationResponse {
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
+
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
+    /// The time at which the Event was created.
+    #[yaserde(rename = "creationTime")]
+    pub creation_time: TimeType,
+
+    #[yaserde(rename = "EventStatus")]
+    pub event_status: EventStatus,
+
+    /// The period during which the Event applies.
+    #[yaserde(rename = "interval")]
+    pub interval: DateTimeInterval,
+
     /// Indicates the amount of energy available.
     #[yaserde(rename = "energyAvailable")]
     pub energy_available: SignedRealEnergy,
@@ -206,30 +230,6 @@ pub struct FlowReservationResponse {
     /// FlowReservationRequest object.
     #[yaserde(rename = "subject")]
     pub subject: MRIDType,
-
-    /// The time at which the Event was created.
-    #[yaserde(rename = "creationTime")]
-    pub creation_time: TimeType,
-
-    #[yaserde(rename = "EventStatus")]
-    pub event_status: EventStatus,
-
-    /// The period during which the Event applies.
-    #[yaserde(rename = "interval")]
-    pub interval: DateTimeInterval,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
 
     /// Indicates whether or not subscriptions are supported for this resource,
     /// and whether or not conditional (thresholds) are supported. If not

--- a/sep2_common/src/packages/fsa.rs
+++ b/sep2_common/src/packages/fsa.rs
@@ -84,25 +84,6 @@ impl Validate for FunctionSetAssignmentsBase {}
 #[yaserde(rename = "FunctionSetAssignments")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct FunctionSetAssignments {
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
-
-    /// Indicates whether or not subscriptions are supported for this resource,
-    /// and whether or not conditional (thresholds) are supported. If not
-    /// specified, is "not subscribable" (0).
-    #[yaserde(attribute, rename = "subscribable")]
-    pub subscribable: Option<SubscribableType>,
-
     #[yaserde(rename = "CustomerAccountListLink")]
     pub customer_account_list_link: Option<CustomerAccountListLink>,
 
@@ -132,6 +113,25 @@ pub struct FunctionSetAssignments {
 
     #[yaserde(rename = "UsagePointListLink")]
     pub usage_point_list_link: Option<UsagePointListLink>,
+
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
+
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
+    /// Indicates whether or not subscriptions are supported for this resource,
+    /// and whether or not conditional (thresholds) are supported. If not
+    /// specified, is "not subscribable" (0).
+    #[yaserde(attribute, rename = "subscribable")]
+    pub subscribable: Option<SubscribableType>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.

--- a/sep2_common/src/packages/identification.rs
+++ b/sep2_common/src/packages/identification.rs
@@ -529,3 +529,23 @@ pub struct SubscribableIdentifiedObject {
 }
 
 impl Validate for SubscribableIdentifiedObject {}
+
+#[cfg(test)]
+use crate::{deserialize, serialize};
+
+#[test]
+fn identified_object_mrid_hex_format() {
+    // MRIDType serializes as uppercase hex with no `0x` prefix and no leading
+    // zeros, matching the spec's representation of HexBinary128 mRIDs.
+    let expected = r#"<IdentifiedObject xmlns="urn:ieee:std:2030.5:ns">
+  <mRID>DEADBEEF</mRID>
+</IdentifiedObject>"#;
+    let obj = IdentifiedObject {
+        mrid: MRIDType(0xDEADBEEF),
+        ..Default::default()
+    };
+    let out = serialize(&obj).unwrap();
+    assert_eq!(expected, out);
+    let round_trip: IdentifiedObject = deserialize(&out).unwrap();
+    assert_eq!(round_trip, obj);
+}

--- a/sep2_common/src/packages/messaging.rs
+++ b/sep2_common/src/packages/messaging.rs
@@ -38,6 +38,19 @@ use sepserde::{YaDeserialize, YaSerialize};
 #[yaserde(rename = "MessagingProgram")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct MessagingProgram {
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
+
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
     #[yaserde(rename = "ActiveTextMessageListLink")]
     pub active_text_message_list_link: Option<ActiveTextMessageListLink>,
 
@@ -51,19 +64,6 @@ pub struct MessagingProgram {
 
     #[yaserde(rename = "TextMessageListLink")]
     pub text_message_list_link: Option<TextMessageListLink>,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
 
     /// Indicates whether or not subscriptions are supported for this resource,
     /// and whether or not conditional (thresholds) are supported. If not
@@ -175,6 +175,30 @@ impl Validate for PriorityType {}
 #[yaserde(rename = "TextMessage")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct TextMessage {
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
+
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
+    /// The time at which the Event was created.
+    #[yaserde(rename = "creationTime")]
+    pub creation_time: TimeType,
+
+    #[yaserde(rename = "EventStatus")]
+    pub event_status: EventStatus,
+
+    /// The period during which the Event applies.
+    #[yaserde(rename = "interval")]
+    pub interval: DateTimeInterval,
+
     /// Indicates the human-readable name of the publisher of the message
     #[yaserde(rename = "originator")]
     pub originator: Option<String20>,
@@ -197,30 +221,6 @@ pub struct TextMessage {
     /// what method to handle the message (truncation, scrolling, etc.).
     #[yaserde(rename = "textMessage")]
     pub text_message: String,
-
-    /// The time at which the Event was created.
-    #[yaserde(rename = "creationTime")]
-    pub creation_time: TimeType,
-
-    #[yaserde(rename = "EventStatus")]
-    pub event_status: EventStatus,
-
-    /// The period during which the Event applies.
-    #[yaserde(rename = "interval")]
-    pub interval: DateTimeInterval,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
 
     /// Indicates whether or not subscriptions are supported for this resource,
     /// and whether or not conditional (thresholds) are supported. If not

--- a/sep2_common/src/packages/metering.rs
+++ b/sep2_common/src/packages/metering.rs
@@ -37,18 +37,6 @@ use super::{
 #[yaserde(rename = "MeterReading")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct MeterReading {
-    #[yaserde(rename = "RateComponentListLink")]
-    pub rate_component_list_link: Option<RateComponentListLink>,
-
-    #[yaserde(rename = "ReadingLink")]
-    pub reading_link: Option<ReadingLink>,
-
-    #[yaserde(rename = "ReadingSetListLink")]
-    pub reading_set_list_link: Option<ReadingSetListLink>,
-
-    #[yaserde(rename = "ReadingTypeLink")]
-    pub reading_type_link: ReadingTypeLink,
-
     /// The global identifier of the object.
     #[yaserde(rename = "mRID")]
     pub mrid: MRIDType,
@@ -61,6 +49,18 @@ pub struct MeterReading {
     /// details.
     #[yaserde(rename = "version")]
     pub version: Option<VersionType>,
+
+    #[yaserde(rename = "RateComponentListLink")]
+    pub rate_component_list_link: Option<RateComponentListLink>,
+
+    #[yaserde(rename = "ReadingLink")]
+    pub reading_link: Option<ReadingLink>,
+
+    #[yaserde(rename = "ReadingSetListLink")]
+    pub reading_set_list_link: Option<ReadingSetListLink>,
+
+    #[yaserde(rename = "ReadingTypeLink")]
+    pub reading_type_link: ReadingTypeLink,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -131,24 +131,17 @@ impl Validate for MeterReadingList {}
 #[yaserde(rename = "Reading")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct Reading {
-    /// The local identifier for this reading within the reading set. localIDs
-    /// are assigned in order of creation time. For interval data, this value
-    /// SHALL increase with each interval time, and for block/tier readings,
-    /// localID SHALL not be specified.
-    #[yaserde(rename = "localID")]
-    pub local_id: Option<HexBinary16>,
+    /// Indicates the consumption block related to the reading. REQUIRED if
+    /// ReadingType numberOfConsumptionBlocks is non-zero. If not specified, is
+    /// assumed to be "0 - N/A".
+    #[yaserde(rename = "consumptionBlock")]
+    pub consumption_block: Option<ConsumptionBlockType>,
 
     /// Indicates whether or not subscriptions are supported for this resource,
     /// and whether or not conditional (thresholds) are supported. If not
     /// specified, is "not subscribable" (0).
     #[yaserde(attribute, rename = "subscribable")]
     pub subscribable: Option<SubscribableType>,
-
-    /// Indicates the consumption block related to the reading. REQUIRED if
-    /// ReadingType numberOfConsumptionBlocks is non-zero. If not specified, is
-    /// assumed to be "0 - N/A".
-    #[yaserde(rename = "consumptionBlock")]
-    pub consumption_block: Option<ConsumptionBlockType>,
 
     /// List of codes indicating the quality of the reading, using specification:
     /// Bit 0 - valid: data that has gone through all required validation checks
@@ -181,6 +174,13 @@ pub struct Reading {
     /// Value in units specified by ReadingType
     #[yaserde(rename = "value")]
     pub value: Option<Int48>,
+
+    /// The local identifier for this reading within the reading set. localIDs
+    /// are assigned in order of creation time. For interval data, this value
+    /// SHALL increase with each interval time, and for block/tier readings,
+    /// localID SHALL not be specified.
+    #[yaserde(rename = "localID")]
+    pub local_id: Option<HexBinary16>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -270,13 +270,6 @@ impl Validate for ReadingList {}
 #[yaserde(rename = "ReadingSet")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct ReadingSet {
-    #[yaserde(rename = "ReadingListLink")]
-    pub reading_list_link: Option<ReadingListLink>,
-
-    /// Specifies the time range during which the contained readings were taken.
-    #[yaserde(rename = "timePeriod")]
-    pub time_period: DateTimeInterval,
-
     /// The global identifier of the object.
     #[yaserde(rename = "mRID")]
     pub mrid: MRIDType,
@@ -289,6 +282,13 @@ pub struct ReadingSet {
     /// details.
     #[yaserde(rename = "version")]
     pub version: Option<VersionType>,
+
+    /// Specifies the time range during which the contained readings were taken.
+    #[yaserde(rename = "timePeriod")]
+    pub time_period: DateTimeInterval,
+
+    #[yaserde(rename = "ReadingListLink")]
+    pub reading_list_link: Option<ReadingListLink>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -496,13 +496,18 @@ impl Validate for ReadingType {}
 #[yaserde(rename = "UsagePoint")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct UsagePoint {
-    /// The LFDI of the source device. This attribute SHALL be present when
-    /// mirroring.
-    #[yaserde(rename = "deviceLFDI")]
-    pub device_lfdi: Option<HexBinary160>,
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
 
-    #[yaserde(rename = "MeterReadingListLink")]
-    pub meter_reading_list_link: Option<MeterReadingListLink>,
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
 
     /// Specifies the roles that apply to the usage point.
     #[yaserde(rename = "roleFlags")]
@@ -518,18 +523,13 @@ pub struct UsagePoint {
     #[yaserde(rename = "status")]
     pub status: UsagePointStatus,
 
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
+    /// The LFDI of the source device. This attribute SHALL be present when
+    /// mirroring.
+    #[yaserde(rename = "deviceLFDI")]
+    pub device_lfdi: Option<HexBinary160>,
 
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
+    #[yaserde(rename = "MeterReadingListLink")]
+    pub meter_reading_list_link: Option<MeterReadingListLink>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.

--- a/sep2_common/src/packages/metering_mirror.rs
+++ b/sep2_common/src/packages/metering_mirror.rs
@@ -33,6 +33,19 @@ use super::{
 #[yaserde(rename = "MirrorMeterReading")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct MirrorMeterReading {
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
+
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
     /// The date and time of the last update.
     #[yaserde(rename = "lastUpdateTime")]
     pub last_update_time: Option<TimeType>,
@@ -49,19 +62,6 @@ pub struct MirrorMeterReading {
 
     #[yaserde(rename = "ReadingType")]
     pub reading_type: Option<ReadingType>,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -148,13 +148,6 @@ impl Validate for MeterReadingBase {}
 #[yaserde(rename = "MirrorReadingSet")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct MirrorReadingSet {
-    #[yaserde(rename = "Reading")]
-    pub reading: Vec<Reading>,
-
-    /// Specifies the time range during which the contained readings were taken.
-    #[yaserde(rename = "timePeriod")]
-    pub time_period: DateTimeInterval,
-
     /// The global identifier of the object.
     #[yaserde(rename = "mRID")]
     pub mrid: MRIDType,
@@ -167,6 +160,13 @@ pub struct MirrorReadingSet {
     /// details.
     #[yaserde(rename = "version")]
     pub version: Option<VersionType>,
+
+    /// Specifies the time range during which the contained readings were taken.
+    #[yaserde(rename = "timePeriod")]
+    pub time_period: DateTimeInterval,
+
+    #[yaserde(rename = "Reading")]
+    pub reading: Vec<Reading>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -191,18 +191,18 @@ impl Validate for MirrorReadingSet {}
 #[yaserde(rename = "MirrorUsagePoint")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct MirrorUsagePoint {
-    /// The LFDI of the device being mirrored.
-    #[yaserde(rename = "deviceLFDI")]
-    pub device_lfdi: HexBinary160,
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
 
-    #[yaserde(rename = "MirrorMeterReading")]
-    pub mirror_meter_reading: Vec<MirrorMeterReading>,
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
 
-    /// POST rate, or how often mirrored data should be POSTed, in seconds. A
-    /// client MAY indicate a preferred postRate when POSTing MirrorUsagePoint. A
-    /// server MAY add or modify postRate to indicate its preferred posting rate.
-    #[yaserde(rename = "postRate")]
-    pub post_rate: Option<Uint32>,
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
 
     /// Specifies the roles that apply to the usage point.
     #[yaserde(rename = "roleFlags")]
@@ -218,18 +218,18 @@ pub struct MirrorUsagePoint {
     #[yaserde(rename = "status")]
     pub status: UsagePointStatus,
 
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
+    /// The LFDI of the device being mirrored.
+    #[yaserde(rename = "deviceLFDI")]
+    pub device_lfdi: HexBinary160,
 
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
+    #[yaserde(rename = "MirrorMeterReading")]
+    pub mirror_meter_reading: Vec<MirrorMeterReading>,
 
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
+    /// POST rate, or how often mirrored data should be POSTed, in seconds. A
+    /// client MAY indicate a preferred postRate when POSTing MirrorUsagePoint. A
+    /// server MAY add or modify postRate to indicate its preferred posting rate.
+    #[yaserde(rename = "postRate")]
+    pub post_rate: Option<Uint32>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -346,10 +346,6 @@ impl Validate for ReadingBase {}
 #[yaserde(rename = "ReadingSetBase")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct ReadingSetBase {
-    /// Specifies the time range during which the contained readings were taken.
-    #[yaserde(rename = "timePeriod")]
-    pub time_period: DateTimeInterval,
-
     /// The global identifier of the object.
     #[yaserde(rename = "mRID")]
     pub mrid: MRIDType,
@@ -362,6 +358,10 @@ pub struct ReadingSetBase {
     /// details.
     #[yaserde(rename = "version")]
     pub version: Option<VersionType>,
+
+    /// Specifies the time range during which the contained readings were taken.
+    #[yaserde(rename = "timePeriod")]
+    pub time_period: DateTimeInterval,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -386,6 +386,19 @@ impl Validate for ReadingSetBase {}
 #[yaserde(rename = "UsagePointBase")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct UsagePointBase {
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
+
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
     /// Specifies the roles that apply to the usage point.
     #[yaserde(rename = "roleFlags")]
     pub role_flags: RoleFlagsType,
@@ -399,19 +412,6 @@ pub struct UsagePointBase {
     /// 1 = on
     #[yaserde(rename = "status")]
     pub status: UsagePointStatus,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.

--- a/sep2_common/src/packages/objects.rs
+++ b/sep2_common/src/packages/objects.rs
@@ -133,17 +133,6 @@ impl Validate for EventStatus {}
 #[yaserde(rename = "Event")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct Event {
-    /// The time at which the Event was created.
-    #[yaserde(rename = "creationTime")]
-    pub creation_time: TimeType,
-
-    #[yaserde(rename = "EventStatus")]
-    pub event_status: EventStatus,
-
-    /// The period during which the Event applies.
-    #[yaserde(rename = "interval")]
-    pub interval: DateTimeInterval,
-
     /// The global identifier of the object.
     #[yaserde(rename = "mRID")]
     pub mrid: MRIDType,
@@ -156,6 +145,17 @@ pub struct Event {
     /// details.
     #[yaserde(rename = "version")]
     pub version: Option<VersionType>,
+
+    /// The time at which the Event was created.
+    #[yaserde(rename = "creationTime")]
+    pub creation_time: TimeType,
+
+    #[yaserde(rename = "EventStatus")]
+    pub event_status: EventStatus,
+
+    /// The period during which the Event applies.
+    #[yaserde(rename = "interval")]
+    pub interval: DateTimeInterval,
 
     /// Indicates whether or not subscriptions are supported for this resource,
     /// and whether or not conditional (thresholds) are supported. If not
@@ -280,6 +280,30 @@ impl Validate for Error {}
 #[yaserde(rename = "RandomizableEvent")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct RandomizableEvent {
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
+
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
+    /// The time at which the Event was created.
+    #[yaserde(rename = "creationTime")]
+    pub creation_time: TimeType,
+
+    #[yaserde(rename = "EventStatus")]
+    pub event_status: EventStatus,
+
+    /// The period during which the Event applies.
+    #[yaserde(rename = "interval")]
+    pub interval: DateTimeInterval,
+
     /// Number of seconds boundary inside which a random value must be selected
     /// to be applied to the associated interval duration, to avoid sudden
     /// synchronized demand changes. If related to price level changes, sign may
@@ -295,30 +319,6 @@ pub struct RandomizableEvent {
     /// default.
     #[yaserde(rename = "randomizeStart")]
     pub randomize_start: Option<OneHourRangeType>,
-
-    /// The time at which the Event was created.
-    #[yaserde(rename = "creationTime")]
-    pub creation_time: TimeType,
-
-    #[yaserde(rename = "EventStatus")]
-    pub event_status: EventStatus,
-
-    /// The period during which the Event applies.
-    #[yaserde(rename = "interval")]
-    pub interval: DateTimeInterval,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
 
     /// Indicates whether or not subscriptions are supported for this resource,
     /// and whether or not conditional (thresholds) are supported. If not

--- a/sep2_common/src/packages/prepayment.rs
+++ b/sep2_common/src/packages/prepayment.rs
@@ -91,6 +91,19 @@ impl Validate for AccountingUnit {}
 #[yaserde(rename = "CreditRegister")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct CreditRegister {
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
+
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
     /// CreditAmount is the amount of credit being added by a particular
     /// CreditRegister transaction. Negative values indicate that credit is being
     /// subtracted.
@@ -116,19 +129,6 @@ pub struct CreditRegister {
     /// implementation or will be defined by one or more other standards.
     #[yaserde(rename = "token")]
     pub token: String32,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -186,6 +186,19 @@ impl Validate for CreditRegisterList {}
 #[yaserde(rename = "Prepayment")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct Prepayment {
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
+
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
     #[yaserde(rename = "AccountBalanceLink")]
     pub account_balance_link: AccountBalanceLink,
 
@@ -241,19 +254,6 @@ pub struct Prepayment {
 
     #[yaserde(rename = "UsagePointLink")]
     pub usage_point_link: Option<UsagePointLink>,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.

--- a/sep2_common/src/packages/pricing.rs
+++ b/sep2_common/src/packages/pricing.rs
@@ -179,6 +179,19 @@ impl Validate for EnvironmentalCost {}
 #[yaserde(rename = "RateComponent")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct RateComponent {
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
+
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
     #[yaserde(rename = "ActiveTimeTariffIntervalListLink")]
     pub active_time_tariff_interval_list_link: Option<ActiveTimeTariffIntervalListLink>,
 
@@ -226,19 +239,6 @@ pub struct RateComponent {
 
     #[yaserde(rename = "TimeTariffIntervalListLink")]
     pub time_tariff_interval_list_link: TimeTariffIntervalListLink,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -307,13 +307,29 @@ impl Validate for RateComponentList {}
 #[yaserde(rename = "TimeTariffInterval")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct TimeTariffInterval {
-    #[yaserde(rename = "ConsumptionTariffIntervalListLink")]
-    pub consumption_tariff_interval_list_link: Option<ConsumptionTariffIntervalListLink>,
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
 
-    /// Indicates the time of use tier related to the reading. If not specified,
-    /// is assumed to be "0 - N/A".
-    #[yaserde(rename = "touTier")]
-    pub tou_tier: TOUType,
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
+    /// The time at which the Event was created.
+    #[yaserde(rename = "creationTime")]
+    pub creation_time: TimeType,
+
+    #[yaserde(rename = "EventStatus")]
+    pub event_status: EventStatus,
+
+    /// The period during which the Event applies.
+    #[yaserde(rename = "interval")]
+    pub interval: DateTimeInterval,
 
     /// Number of seconds boundary inside which a random value must be selected
     /// to be applied to the associated interval duration, to avoid sudden
@@ -331,29 +347,13 @@ pub struct TimeTariffInterval {
     #[yaserde(rename = "randomizeStart")]
     pub randomize_start: Option<OneHourRangeType>,
 
-    /// The time at which the Event was created.
-    #[yaserde(rename = "creationTime")]
-    pub creation_time: TimeType,
+    #[yaserde(rename = "ConsumptionTariffIntervalListLink")]
+    pub consumption_tariff_interval_list_link: Option<ConsumptionTariffIntervalListLink>,
 
-    #[yaserde(rename = "EventStatus")]
-    pub event_status: EventStatus,
-
-    /// The period during which the Event applies.
-    #[yaserde(rename = "interval")]
-    pub interval: DateTimeInterval,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
+    /// Indicates the time of use tier related to the reading. If not specified,
+    /// is assumed to be "0 - N/A".
+    #[yaserde(rename = "touTier")]
+    pub tou_tier: TOUType,
 
     /// Indicates whether or not subscriptions are supported for this resource,
     /// and whether or not conditional (thresholds) are supported. If not
@@ -517,6 +517,19 @@ impl Validate for TimeTariffIntervalList {}
 #[yaserde(rename = "TariffProfile")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct TariffProfile {
+    /// The global identifier of the object.
+    #[yaserde(rename = "mRID")]
+    pub mrid: MRIDType,
+
+    /// The description is a human readable text describing or naming the object.
+    #[yaserde(rename = "description")]
+    pub description: Option<String32>,
+
+    /// Contains the version number of the object. See the type definition for
+    /// details.
+    #[yaserde(rename = "version")]
+    pub version: Option<VersionType>,
+
     /// The currency code indicating the currency for this TariffProfile.
     #[yaserde(rename = "currency")]
     pub currency: Option<CurrencyCode>,
@@ -543,19 +556,6 @@ pub struct TariffProfile {
     /// The kind of service provided by this usage point.
     #[yaserde(rename = "serviceCategoryKind")]
     pub service_category_kind: ServiceKind,
-
-    /// The global identifier of the object.
-    #[yaserde(rename = "mRID")]
-    pub mrid: MRIDType,
-
-    /// The description is a human readable text describing or naming the object.
-    #[yaserde(rename = "description")]
-    pub description: Option<String32>,
-
-    /// Contains the version number of the object. See the type definition for
-    /// details.
-    #[yaserde(rename = "version")]
-    pub version: Option<VersionType>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.

--- a/sep2_common/src/packages/primitives.rs
+++ b/sep2_common/src/packages/primitives.rs
@@ -14,7 +14,6 @@ use crate::traits::Validate;
 /// We purposefully don't use type aliases, as our procedural macros cannot determine whether a type is a primitive using an alias to it
 /// This means types that are just primitive aliases cannot be used without these primitive newtypes.
 /// We require newtypes for non-standard integer types regardless.
-
 /// Unsigned integer, max inclusive 255 (2^8-1)
 #[derive(Default, Hash, PartialEq, PartialOrd, Eq, Ord, Clone, Copy, Debug, PrimitiveYaSerde)]
 pub struct Uint8(pub u8);

--- a/sep2_common/src/packages/pubsub.rs
+++ b/sep2_common/src/packages/pubsub.rs
@@ -61,6 +61,12 @@ impl Validate for SubscriptionBase {}
 #[yaserde(rename = "Subscription")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct Subscription {
+    /// The resource for which the subscription applies. Query string parameters
+    /// SHALL NOT be specified when subscribing to list resources. Should a query
+    /// string parameter be specified, servers SHALL ignore them.
+    #[yaserde(rename = "subscribedResource")]
+    pub subscribed_resource: String,
+
     #[yaserde(rename = "Condition")]
     pub condition: Option<Condition>,
 
@@ -101,12 +107,6 @@ pub struct Subscription {
     /// absolute URI, not a relative reference.
     #[yaserde(rename = "notificationURI")]
     pub notification_uri: String,
-
-    /// The resource for which the subscription applies. Query string parameters
-    /// SHALL NOT be specified when subscribing to list resources. Should a query
-    /// string parameter be specified, servers SHALL ignore them.
-    #[yaserde(rename = "subscribedResource")]
-    pub subscribed_resource: String,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -180,6 +180,12 @@ impl Validate for SubscriptionList {}
     namespace = "xsi: http://www.w3.org/2001/XMLSchema-instance"
 )]
 pub struct Notification<T: SEResource> {
+    /// The resource for which the subscription applies. Query string parameters
+    /// SHALL NOT be specified when subscribing to list resources. Should a query
+    /// string parameter be specified, servers SHALL ignore them.
+    #[yaserde(rename = "subscribedResource")]
+    pub subscribed_resource: String,
+
     /// The new location of the resource, if moved. This attribute SHALL be a
     /// fully-qualified absolute URI, not a relative reference.
     #[yaserde(rename = "newResourceURI")]
@@ -204,12 +210,6 @@ pub struct Notification<T: SEResource> {
     /// reference.
     #[yaserde(rename = "subscriptionURI")]
     pub subscription_uri: String,
-
-    /// The resource for which the subscription applies. Query string parameters
-    /// SHALL NOT be specified when subscribing to list resources. Should a query
-    /// string parameter be specified, servers SHALL ignore them.
-    #[yaserde(rename = "subscribedResource")]
-    pub subscribed_resource: String,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.

--- a/sep2_common/src/packages/response.rs
+++ b/sep2_common/src/packages/response.rs
@@ -129,32 +129,6 @@ impl Validate for AppliedTargetReduction {}
 #[yaserde(rename = "DrResponse")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct DrResponse {
-    #[yaserde(rename = "ApplianceLoadReduction")]
-    pub appliance_load_reduction: Option<ApplianceLoadReduction>,
-
-    #[yaserde(rename = "AppliedTargetReduction")]
-    pub applied_target_reduction: Option<AppliedTargetReduction>,
-
-    #[yaserde(rename = "DutyCycle")]
-    pub duty_cycle: Option<DutyCycle>,
-
-    #[yaserde(rename = "Offset")]
-    pub offset: Option<Offset>,
-
-    /// Indicates the amount of time, in seconds, that the client partially
-    /// opts-out during the demand response event. When overriding within the
-    /// allowed override duration, the client SHALL send a partial opt-out
-    /// (Response status code 8) for partial opt-out upon completion, with the
-    /// total time the event was overridden (this attribute) populated. The
-    /// client SHALL send a no participation status response (status type 10) if
-    /// the user partially opts-out for longer than
-    /// EndDeviceControl.overrideDuration.
-    #[yaserde(rename = "overrideDuration")]
-    pub override_duration: Option<Uint16>,
-
-    #[yaserde(rename = "SetPoint")]
-    pub set_point: Option<SetPoint>,
-
     /// The createdDateTime field contains the date and time when the
     /// acknowledgement/status occurred in the client. The client will provide
     /// the timestamp to ensure the proper time is captured in case the response
@@ -184,6 +158,32 @@ pub struct DrResponse {
     /// originating event. It is populated with the mRID of the original object.
     #[yaserde(rename = "subject")]
     pub subject: MRIDType,
+
+    #[yaserde(rename = "ApplianceLoadReduction")]
+    pub appliance_load_reduction: Option<ApplianceLoadReduction>,
+
+    #[yaserde(rename = "AppliedTargetReduction")]
+    pub applied_target_reduction: Option<AppliedTargetReduction>,
+
+    #[yaserde(rename = "DutyCycle")]
+    pub duty_cycle: Option<DutyCycle>,
+
+    #[yaserde(rename = "Offset")]
+    pub offset: Option<Offset>,
+
+    /// Indicates the amount of time, in seconds, that the client partially
+    /// opts-out during the demand response event. When overriding within the
+    /// allowed override duration, the client SHALL send a partial opt-out
+    /// (Response status code 8) for partial opt-out upon completion, with the
+    /// total time the event was overridden (this attribute) populated. The
+    /// client SHALL send a no participation status response (status type 10) if
+    /// the user partially opts-out for longer than
+    /// EndDeviceControl.overrideDuration.
+    #[yaserde(rename = "overrideDuration")]
+    pub override_duration: Option<Uint16>,
+
+    #[yaserde(rename = "SetPoint")]
+    pub set_point: Option<SetPoint>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.
@@ -268,9 +268,6 @@ impl<T: SEResponse + Ord> Validate for ResponseList<T> {}
 #[yaserde(rename = "ResponseSet")]
 #[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
 pub struct ResponseSet {
-    #[yaserde(rename = "ResponseListLink")]
-    pub response_list_link: Option<ResponseListLink>,
-
     /// The global identifier of the object.
     #[yaserde(rename = "mRID")]
     pub mrid: MRIDType,
@@ -283,6 +280,9 @@ pub struct ResponseSet {
     /// details.
     #[yaserde(rename = "version")]
     pub version: Option<VersionType>,
+
+    #[yaserde(rename = "ResponseListLink")]
+    pub response_list_link: Option<ResponseListLink>,
 
     /// A reference to the resource address (URI). Required in a response to a
     /// GET, ignored otherwise.

--- a/sep2_common/src/packages/types.rs
+++ b/sep2_common/src/packages/types.rs
@@ -8,9 +8,7 @@ use std::str::FromStr;
 
 use crate::traits::Validate;
 
-use super::primitives::{
-    HexBinary128, Int32, Int48, Int64, String32, String42, Uint16, Uint32, Uint48,
-};
+use super::primitives::{Int32, Int48, Int64, String32, String42, Uint16, Uint32, Uint48};
 
 #[derive(
     Default, PartialEq, PartialOrd, Eq, Ord, Debug, Clone, Copy, YaSerialize, YaDeserialize,
@@ -234,7 +232,7 @@ impl DstRuleType {
         operator: u32,
         month: u32,
     ) -> Self {
-        let mut out = DstRuleType(0);
+        let mut out = Self(0);
         out.set_seconds(seconds);
         out.set_hours(hours);
         out.set_day_of_week(day_of_week);
@@ -363,7 +361,30 @@ impl Validate for KindType {}
 pub type LocaleType = String42;
 
 /// A Master Resource Identifier
-pub type MRIDType = HexBinary128;
+#[derive(Default, Hash, PartialEq, PartialOrd, Eq, Ord, Debug, Clone, Copy, DefaultYaSerde)]
+pub struct MRIDType(pub u128);
+
+impl Validate for MRIDType {}
+
+impl Display for MRIDType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:X}", self.0)
+    }
+}
+
+impl FromStr for MRIDType {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let raw = s
+            .strip_prefix("0x")
+            .or_else(|| s.strip_prefix("0X"))
+            .unwrap_or(s);
+        u128::from_str_radix(raw, 16)
+            .map(MRIDType)
+            .context("MRIDType must be a hexadecimal value")
+    }
+}
 
 /// A signed time offset, typically applied to a Time value, expressed in seconds, with range −3600 to 3600
 #[derive(Default, PartialEq, Eq, Debug, Clone, Copy, DefaultYaSerde)]
@@ -372,11 +393,11 @@ pub struct OneHourRangeType(i16);
 impl Validate for OneHourRangeType {}
 
 impl OneHourRangeType {
-    pub fn new(val: i16) -> Option<OneHourRangeType> {
+    pub fn new(val: i16) -> Option<Self> {
         if !(-3600..=3600).contains(&val) {
             None
         } else {
-            Some(OneHourRangeType(val))
+            Some(Self(val))
         }
     }
     pub fn get(&self) -> i16 {
@@ -389,7 +410,7 @@ impl FromStr for OneHourRangeType {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         s.parse()
             .ok()
-            .and_then(OneHourRangeType::new)
+            .and_then(Self::new)
             .context("OneHourRangeType value must be between -3600 and 3600")
     }
 }
@@ -410,11 +431,11 @@ pub struct Percent(u16);
 impl Validate for Percent {}
 
 impl Percent {
-    pub fn new(val: u16) -> Option<Percent> {
+    pub fn new(val: u16) -> Option<Self> {
         if val > 10_000 {
             None
         } else {
-            Some(Percent(val))
+            Some(Self(val))
         }
     }
     pub fn get(&self) -> u16 {
@@ -428,7 +449,7 @@ impl FromStr for Percent {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         s.parse()
             .ok()
-            .and_then(Percent::new)
+            .and_then(Self::new)
             .context("Percent value must be between 0 and 10000")
     }
 }
@@ -470,11 +491,11 @@ pub struct PINType(u32);
 impl Validate for PINType {}
 
 impl PINType {
-    pub fn new(val: u32) -> Option<PINType> {
+    pub fn new(val: u32) -> Option<Self> {
         if val > 999_999 {
             None
         } else {
-            Some(PINType(val))
+            Some(Self(val))
         }
     }
     pub fn get(&self) -> u32 {
@@ -487,7 +508,7 @@ impl FromStr for PINType {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         s.parse()
             .ok()
-            .and_then(PINType::new)
+            .and_then(Self::new)
             .context("PINType value must be between 0 and 999,999")
     }
 }
@@ -499,11 +520,7 @@ impl Display for PINType {
 }
 
 /// For many variants there is no Internal System of Units designated prefix, and as such the number is used as a name instead.
-#[derive(
-    Default, PartialEq, PartialOrd, Eq, Ord, Debug, Clone, Copy, YaSerialize, YaDeserialize,
-)]
-#[yaserde(rename = "PowerOfTenMultiplierType")]
-#[yaserde(namespace = "urn:ieee:std:2030.5:ns")]
+#[derive(Default, PartialEq, PartialOrd, Eq, Ord, Debug, Clone, Copy, DefaultYaSerde)]
 #[repr(i8)]
 pub enum PowerOfTenMultiplierType {
     Nano = -9,
@@ -529,6 +546,50 @@ pub enum PowerOfTenMultiplierType {
 }
 
 impl Validate for PowerOfTenMultiplierType {}
+
+impl PowerOfTenMultiplierType {
+    pub fn new(val: i8) -> Option<Self> {
+        match val {
+            -9 => Some(Self::Nano),
+            -8 => Some(Self::NegativeEight),
+            -7 => Some(Self::NegativeSeven),
+            -6 => Some(Self::Micro),
+            -5 => Some(Self::NegativeFive),
+            -4 => Some(Self::NegativeFour),
+            -3 => Some(Self::Milli),
+            -2 => Some(Self::Centi),
+            -1 => Some(Self::Deci),
+            0 => Some(Self::None),
+            1 => Some(Self::Deca),
+            2 => Some(Self::Hecto),
+            3 => Some(Self::Kilo),
+            4 => Some(Self::Four),
+            5 => Some(Self::Five),
+            6 => Some(Self::Mega),
+            7 => Some(Self::Seven),
+            8 => Some(Self::Eight),
+            9 => Some(Self::Giga),
+            _ => None,
+        }
+    }
+}
+
+impl FromStr for PowerOfTenMultiplierType {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse::<i8>()
+            .ok()
+            .and_then(Self::new)
+            .context("PowerOfTenMultiplierType value must be an integer between -9 and 9")
+    }
+}
+
+impl Display for PowerOfTenMultiplierType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", *self as i8)
+    }
+}
 
 #[derive(
     Default, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug, YaSerialize, YaDeserialize,
@@ -600,11 +661,11 @@ pub struct SFDIType(u64);
 impl Validate for SFDIType {}
 
 impl SFDIType {
-    pub fn new(val: u64) -> Option<SFDIType> {
+    pub fn new(val: u64) -> Option<Self> {
         if val > 1_099_511_627_775 {
             None
         } else {
-            Some(SFDIType(val))
+            Some(Self(val))
         }
     }
     pub fn get(&self) -> u64 {
@@ -617,7 +678,7 @@ impl FromStr for SFDIType {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         s.parse()
             .ok()
-            .and_then(SFDIType::new)
+            .and_then(Self::new)
             .context("SFDIType value must be between -10,000 and 10,000")
     }
 }
@@ -635,11 +696,11 @@ pub struct SignedPercent(i16);
 impl Validate for SignedPercent {}
 
 impl SignedPercent {
-    pub fn new(val: i16) -> Option<SignedPercent> {
+    pub fn new(val: i16) -> Option<Self> {
         if !(-10_000..=10_000).contains(&val) {
             None
         } else {
-            Some(SignedPercent(val))
+            Some(Self(val))
         }
     }
     pub fn get(&self) -> i16 {
@@ -652,7 +713,7 @@ impl FromStr for SignedPercent {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         s.parse()
             .ok()
-            .and_then(SignedPercent::new)
+            .and_then(Self::new)
             .context("SignedPercent value must be between -10,000 and 10,000")
     }
 }
@@ -833,6 +894,28 @@ pub enum UsagePointStatus {
     #[default]
     Off,
     On,
+}
+
+#[cfg(test)]
+use crate::{deserialize, serialize};
+
+#[test]
+fn real_energy_negative_multiplier() {
+    // Regression: PowerOfTenMultiplierType's Display previously sign-extended
+    // the i8 discriminant through u32, emitting "4294967293" for Milli (-3)
+    // instead of "-3".
+    let expected = r#"<RealEnergy xmlns="urn:ieee:std:2030.5:ns">
+  <multiplier>-3</multiplier>
+  <value>42</value>
+</RealEnergy>"#;
+    let energy = RealEnergy {
+        multiplier: PowerOfTenMultiplierType::Milli,
+        value: super::primitives::Uint48(42),
+    };
+    let out = serialize(&energy).unwrap();
+    assert_eq!(expected, out);
+    let round_trip: RealEnergy = deserialize(&out).unwrap();
+    assert_eq!(round_trip, energy);
 }
 
 #[test]

--- a/sep2_common/tests/packages/pubsub.rs
+++ b/sep2_common/tests/packages/pubsub.rs
@@ -41,6 +41,7 @@ fn notification_example() {
     let orig = create_notif_example();
     let out = serialize(&orig).unwrap();
     let expected = r#"<Notification xmlns="urn:ieee:std:2030.5:ns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <subscribedResource>/upt/0/mr/4/r</subscribedResource>
   <Resource xsi:type="Reading">
     <timePeriod>
       <duration>0</duration>
@@ -50,10 +51,9 @@ fn notification_example() {
   </Resource>
   <status>0</status>
   <subscriptionURI>/edev/8/sub/5</subscriptionURI>
-  <subscribedResource>/upt/0/mr/4/r</subscribedResource>
 </Notification>"#;
     assert_eq!(expected, out);
-    let new: Notification<Reading> = deserialize(&expected).unwrap();
+    let new: Notification<Reading> = deserialize(expected).unwrap();
     assert_eq!(orig, new);
     let example: Notification<Reading> = deserialize(NTF_16_06_04).unwrap();
     assert_eq!(example, new);
@@ -63,6 +63,7 @@ fn notification_example() {
 fn notification_list_default() {
     let expected = r#"<NotificationList xmlns="urn:ieee:std:2030.5:ns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" all="2" results="0">
   <Notification>
+    <subscribedResource>/upt/0/mr/4/r</subscribedResource>
     <Resource xsi:type="Reading">
       <timePeriod>
         <duration>0</duration>
@@ -72,9 +73,9 @@ fn notification_list_default() {
     </Resource>
     <status>0</status>
     <subscriptionURI>/edev/8/sub/5</subscriptionURI>
-    <subscribedResource>/upt/0/mr/4/r</subscribedResource>
   </Notification>
   <Notification>
+    <subscribedResource>/upt/0/mr/4/r</subscribedResource>
     <Resource xsi:type="Reading">
       <timePeriod>
         <duration>0</duration>
@@ -84,7 +85,6 @@ fn notification_list_default() {
     </Resource>
     <status>0</status>
     <subscriptionURI>/edev/8/sub/5</subscriptionURI>
-    <subscribedResource>/upt/0/mr/4/r</subscribedResource>
   </Notification>
 </NotificationList>"#;
     let res: Notification<Reading> = create_notif_example();


### PR DESCRIPTION
Resolves XSD validation failures (refs #10) by reordering struct fields to match XSD inheritance order, correcting CSIP-AUS extension wiring, and fixing primitive type serialization to be spec-conformant.

## Field reordering

- Reorder 185 element-bearing structs across 28 package files so inherited base elements precede each type's own elements, matching the order required by IEEE 2030.5 XSD validators. Touches billing, conn_point, dcap, der, drlc, edev, flow_reservation, fsa, identification, messaging, metering, metering_mirror, objects, prepayment, pricing, pubsub, response, and types packages.

## CSIP-AUS extensions

- `DERCapability.doeModesSupported`: move to the end of the element block, matching `csipaus-core.xsd`'s redefine.
- `DERControlBase`: place `rampTms` before the csipaus extension block (`opModImpLimW`, `opModExpLimW`, `opModGenLimW`, `opModLoadLimW`) so base elements precede extensions.
- `DERSettings`: add the missing `doeModesEnabled` field (`Option<DOEControlType>`) gated on `feature = "csip_aus"`.
- `DOEControlType`: change bitflags backing from `u16` to `u8` to match `csipaus-ext.xsd`'s `HexBinary8` extension.
- `EndDevice`: move `ConnectionPointLink` to the end of `EndDevice`'s own element block.
- Fix `"ConnectionPointLink "` trailing-space typo in yaserde rename.

## Spec-conformant primitives

- `MRIDType`: promote from `type MRIDType = HexBinary128;` to a newtype with custom `Display` (`{:X}`, uppercase hex, no `0x` prefix, no leading zeros) and `FromStr` (hex parsing with optional `0x`/`0X` prefix, `anyhow::Error`). Matches the spec's mRID representation.
- `PowerOfTenMultiplierType`: replace auto-derived `YaSerialize` with a manual `Display`/`FromStr` via `DefaultYaSerde`. The derived path sign-extended the `i8` discriminant through `u32`, emitting `"4294967293"` for `Milli` (-3) instead of `"-3"`.
- `mrid_gen`: return `MRIDType` directly instead of `HexBinary128`.
- Use `Self` in newtype constructors (`DstRuleType`, `OneHourRangeType`, `Percent`, `PINType`, `SFDIType`, `SignedPercent`) to match house style.

## Dependency

- Bump `sepserde` to 0.8.3, picking up the `HexBinaryYaSerde` fix that emits fixed-width hex (e.g. `<alarmStatus>00000001</alarmStatus>` instead of variable-width `"1"`) and parses input as hex rather than decimal.

Closes #10
Closes #11