### PR TITLE
chore: release sep2_common 0.2.0

### DIFF
--- a/sep2_common/Cargo.toml
+++ b/sep2_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sep2_common"
 description = "A Rust library for building IEEE 2030.5 Clients & Servers"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ethan Dickson <ethanndickson@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Prepares `sep2_common` for a new crates.io release by bumping the manifest version from `0.1.0` to `0.2.0`.

A minor bump under Cargo's 0.x semantics signals breaking changes. PR #14 introduced several:

- `MRIDType` changed from `type MRIDType = HexBinary128` (alias) to `pub struct MRIDType(pub u128)` newtype.
- `DOEControlType` bitflags backing changed from `u16` to `u8` to match `csipaus-ext.xsd`'s `HexBinary8`. Both API and wire format change.
- `DERSettings` gained `doe_modes_enabled: Option<DOEControlType>` (gated on `feature = "csip_aus"`).
- `DERControlBase` reordered: `rampTms` now precedes the csipaus extension block (`opModImpLimW`, `opModExpLimW`, `opModGenLimW`, `opModLoadLimW`).
- `DERCapability.doeModesSupported` moved to end of element block.
- `EndDevice.ConnectionPointLink` moved to end of own element block; trailing-space typo in the yaserde rename fixed.
- 185 element-bearing structs reordered so inherited base elements precede each type's own elements (XSD-canonical order). Wire output observably changes.
- `mrid_gen` return type changed from `HexBinary128` to `MRIDType`.
- `PowerOfTenMultiplierType` now uses a manual `Display`/`FromStr` via `DefaultYaSerde` (fixes the `4294967293` sign-extension bug for negative variants).
- `sepserde` dep bumped to `0.8.3`, which emits fixed-width hex for `HexBinary*` and parses input as hex rather than decimal.

`sep2_common_derive` is unchanged on disk vs the published `0.1.0`, so it stays at `0.1.0`.

Validated locally with `cargo publish --dry-run -p sep2_common --features all`: 40 files, 516.1 KiB packed, verification build compiled cleanly against published `sep2_common_derive 0.1.0` and `sepserde 0.8.3`.

Actual `cargo publish` is a post-merge action.
