### PR TITLE
feat: add mrid_with_id for deterministic mRIDs

### DIFF
--- a/sep2_common/src/lib.rs
+++ b/sep2_common/src/lib.rs
@@ -103,6 +103,22 @@ pub fn mrid_gen(pen: Pen) -> MRIDType {
     MRIDType(((random as u128) << 64) | ((middle as u128) << 32) | u128::from(pen.get()))
 }
 
+/// Given an IANA Private Enterprise Number (PEN) and a 96-bit resource id,
+/// produce a deterministic mRID.
+///
+/// The supplied [`Pen`] occupies bits 0-31, and `id` occupies bits 32-127.
+/// Two calls with the same `pen` and `id` always produce the same mRID,
+/// allowing callers to recompute the mRID for an existing resource (e.g. to
+/// avoid recreating it on the server).
+///
+/// Returns `None` if `id` does not fit in 96 bits.
+pub fn mrid_with_id(pen: Pen, id: u128) -> Option<MRIDType> {
+    if id >> 96 != 0 {
+        return None;
+    }
+    Some(MRIDType((id << 32) | u128::from(pen.get())))
+}
+
 #[test]
 fn mrid_contains_pen() {
     let pen = Pen::ieee2030_5(1337);
@@ -133,6 +149,30 @@ fn csipaus_pen_bounds() {
     assert_eq!(Some(Pen::ieee2030_5(0x9999_9999)), Pen::csipaus(99_999_999));
     assert_eq!(None, Pen::csipaus(100_000_000));
     assert_eq!(None, Pen::csipaus(u32::MAX));
+}
+
+#[test]
+fn mrid_with_id_is_deterministic() {
+    let pen = Pen::ieee2030_5(1337);
+    let id = 0x0000_0000_DEAD_BEEF_CAFE_BABE_1234_5678;
+    assert_eq!(mrid_with_id(pen, id), mrid_with_id(pen, id));
+}
+
+#[test]
+fn mrid_with_id_places_pen_and_id() {
+    let pen = Pen::ieee2030_5(0xDEAD_BEEF);
+    let id: u128 = 0x1234_5678_9ABC_DEF0_1122_3344;
+    let mrid = mrid_with_id(pen, id).unwrap();
+    assert_eq!(mrid.0 as u32, 0xDEAD_BEEF);
+    assert_eq!(mrid.0 >> 32, id);
+}
+
+#[test]
+fn mrid_with_id_rejects_oversized_id() {
+    let pen = Pen::ieee2030_5(0);
+    assert!(mrid_with_id(pen, (1u128 << 96) - 1).is_some());
+    assert!(mrid_with_id(pen, 1u128 << 96).is_none());
+    assert!(mrid_with_id(pen, u128::MAX).is_none());
 }
 
 #[test]


### PR DESCRIPTION
`mrid_gen` produces a fresh, non-deterministic mRID on every call: the high 96 bits combine a random `u64` with a time/counter mix. That is the right tool for "I'm creating a brand new resource", but it makes it impossible for a caller to recompute the mRID for a resource they have already created. Anyone implementing a find-or-create flow (e.g. listing resources from a server and matching them against locally-known identifiers before deciding whether to POST a new one) has to either persist every previously-generated mRID, or accept duplicate resources.

IEEE 2030.5 requires the IANA PEN in the low 32 bits and a unique 96-bit id in the remainder:

> The IANA PEN [PEN] provider ID SHALL be specified in bits 0-31, the least-significant bits, and objects created by that provider SHALL be assigned unique IDs with the remaining 96 bits.

Uniqueness is a constraint on the value of the high 96 bits, not on how they are produced. A deterministic function of `(PEN, resource identity)` is unique within that provider's namespace by construction, and is therefore spec-compliant.

This PR adds `mrid_with_id(pen: Pen, id: u128) -> Option<MRIDType>` as a complement to `mrid_gen`:

- Bits 0-31 are the encoded `Pen` (IEEE 2030.5 or CSIP-AUS, exactly as for `mrid_gen`).
- Bits 32-127 are the caller-supplied 96-bit `id`.
- Returns `None` if `id` does not fit in 96 bits.

Callers can now derive `id` from whatever identity makes sense for their resource (primary key, composite key, hash, etc.) and re-derive the same mRID later to look up or compare against existing server state, without persisting a mapping table.

`mrid_gen` is unchanged.
